### PR TITLE
feat: upload binary after build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,11 @@ jobs:
 
   publish-release:
     runs-on: ubuntu-latest
+    needs: build-release
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build Release
         uses: softprops/action-gh-release@v1
+        with:
+          files: target/release/git-checkout-interactive-rust


### PR DESCRIPTION
This commit will make the release workflow upload the release binary as an artifact on the release. 