### PR TITLE
fix: release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,28 +9,24 @@ on:
 jobs:
   test:
     uses: ./.github/workflows/integration.yml
-  build-release:
+  release:
     name: Github Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions-rs/cargo@v1
+      - name: Build Release
+        uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release
-
-  publish-release:
-    runs-on: ubuntu-latest
-    needs: build-release
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build Release
+      - name: Publish Release
         uses: softprops/action-gh-release@v1
         with:
           files: target/release/git-checkout-interactive-rust


### PR DESCRIPTION
This commit will change the release workflow to run in the same container so that the build files are able to be referenced by the publish release actions