### PR TITLE
feat: publish to crates on relase

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: target/release/git-checkout-interactive-rust
+      - name: Publish Crate
+        run: cargo publish --token ${CARGO_REGISTRY_TOKEN}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
The PR adds a workflow step to publish the package to crates.io at the end of the release workflow. 