### PR TITLE
feat: add metadata to cargo toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 name = "gci"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
+keywords = ["cli", "development", "git", "github", "devops"]
+categories = ["command-line-utilities", "development-tools"]
+description = "Interactively checkout the branches on your git repository"
+homepage = "https://github.com/jiito/gci"
+repository = "https://github.com/jiito/gci"
+readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This PR adds metadata to the cargo toml to prepare for a release on Crates.io