### PR TITLE
fix: exit process on SIGINT

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::process::exit;
+
 use git2::Repository;
 use inquire::error::InquireError;
 use inquire::Select;
@@ -64,7 +66,8 @@ fn pp_branches<'a>(branches: &'a [(git2::Branch, git2::BranchType)]) -> &'a str 
 
     match ans {
         Ok(ans) => ans,
-        Err(_) => panic!("The shopping list could not be processed"),
+        // gracefully shutdown
+        Err(_) => exit(0),
     }
 }
 


### PR DESCRIPTION
Fixes #16.

## Changes 
1. Exits the process with the 0 code. 

This does not do any cleanup as discussed [here](https://internals.rust-lang.org/t/cleanly-exiting-the-program-in-rust/5501), so maybe look to amend this in the future. 